### PR TITLE
medhub consent phase 1

### DIFF
--- a/htdocs/api/v0.0.3-dev/.htaccess
+++ b/htdocs/api/v0.0.3-dev/.htaccess
@@ -26,6 +26,8 @@ RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.\-]+)/instruments/([a-zA-Z0-9_.]+)
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.\-]+)/instruments/([a-zA-Z0-9_.]+)/dde$ candidates/InstrumentData.php?Instrument=$3&Visit=$2&CandID=$1&DDE=true&PrintInstrumentData=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.\-]+)/instruments/([a-zA-Z0-9_.]+)/flags$ candidates/InstrumentData.php?Instrument=$3&Visit=$2&CandID=$1&flags=true&PrintInstrumentData=true [L]
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.\-]+)/instruments/([a-zA-Z0-9_.]+)/dde/flags$ candidates/InstrumentData.php?Instrument=$3&Visit=$2&CandID=$1&DDE=true&flags=true&PrintInstrumentData=true [L]
+##Kev Addition below
+RewriteRule ^medhubConsent(/*)$ MedhubConsent.php?PrintCandidates=true [L]
 
 ## Imaging API related URLs
 RewriteRule ^candidates/([0-9]+)/([a-zA-Z0-9_.]+)/images$ candidates/visits/Images.php?CandID=$1&VisitLabel=$2&PrintImages=true [L]

--- a/htdocs/api/v0.0.3-dev/APIBase.php
+++ b/htdocs/api/v0.0.3-dev/APIBase.php
@@ -79,6 +79,14 @@ abstract class APIBase
                 $this->error("User not authenticated");
                 $this->safeExit(0);
             }
+
+            $user = \User::singleton();
+            // If the user has the medhub permission they will be blocked from any endpoints not containing medhub
+            if (!str_contains($_SERVER['REQUEST_URI'],"/medhubConsent") && $user->hasPermission('medhub')) {
+                $this->header("HTTP/1.1 401 Unauthorized");
+                $this->error("Insufficient permissions to access this endpoint");
+                $this->safeExit(0);
+            }
         }
 
         $this->DB = $this->Factory->database();

--- a/htdocs/api/v0.0.3-dev/MedhubConsent.php
+++ b/htdocs/api/v0.0.3-dev/MedhubConsent.php
@@ -69,6 +69,12 @@ class MedhubConsent extends APIBase {
                 $this->header("HTTP/1.1 400 Bad Request");
                 $this->safeExit(0);
             }
+            if (!preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/',$consentList[$conName]['Date']))
+                $this->error("Invalid Date Format for" . $conName . " expected date format is yyyy-mm-dd");
+                $this->header("HTTP/1.1 400 Bad Request");
+                $this->safeExit(0);
+
+            }
         }
 
 
@@ -82,14 +88,14 @@ class MedhubConsent extends APIBase {
         $entryDate = $candidTimeUsed['EntryDate'];
         $candid = $candidTimeUsed['CandidateID'];
         if (empty($candidTimeUsed) || $candidTimeUsed['AlreadyUsed'] == 'TRUE'){
-            $this->error("Data incomplete");
+            $this->error("Data incomplete: token does not exist or has already been used");
             $this->header("HTTP/1.1 400 Bad Request");
             $this->safeExit(0);
         }
 
         //Checks if token more than a ~month old
         if((time()-(60*60*24*30)) > strtotime($entryDate)){
-            $this->error("Date check failed");
+            $this->error("Date check failed: Token has expired");
             $this->header("HTTP/1.1 400 Bad Request");
             $this->safeExit(0);
         }

--- a/htdocs/api/v0.0.3-dev/MedhubConsent.php
+++ b/htdocs/api/v0.0.3-dev/MedhubConsent.php
@@ -1,0 +1,264 @@
+<?php
+
+
+namespace Loris\API;
+use http\Env\Response;
+
+set_include_path(get_include_path() . ":" . __DIR__);
+require_once 'APIBase.php';
+
+
+
+class MedhubConsent extends APIBase {
+
+
+
+    var $requestData;
+
+
+    /**
+     *  Candidates request handler
+     *
+     * @param string $method The HTTP request method of the request
+     * @param array  $data   The data that was POSTed to the request
+     */
+
+
+
+    public function __construct($method, $data=null)
+    {
+
+
+
+
+        $this->AllowedMethods = [
+            'PUT'
+        ];
+
+        $this->RequestData    = $data;
+
+        parent::__construct($method);
+    }
+
+
+
+    public function handlePUT()
+    {
+
+        $token = null;
+        $consentList = null;
+
+
+        $candid = null;
+
+        $data   = $this->RequestData;
+        if ($data === null) {
+            $this->header("HTTP/1.1 400 Bad Request");
+            $this->error("Can't parse data");
+            $this->safeExit(0);
+        }
+
+
+        if (!isset($data['Token'])) {
+            $this->header("HTTP/1.1 400 Bad Request");
+            $this->error("There is no Token object in the PUT data");
+            $this->safeExit(0);
+        }
+
+        if (!isset($data['ConsentList'])) {
+            $this->header("HTTP/1.1 400 Bad Request");
+            $this->error("There is no Consent List object in the PUT data");
+            $this->safeExit(0);
+        }
+
+        //Tries to select CandID + entry date for the given token --> later throws and error and dies if nothing found
+        $token = $data['Token'];
+        $ConsentList = $data['ConsentList'];
+
+        $candidTime = $this->DB->pselect(
+            "SELECT CandidateID, EntryDate
+                FROM medhub_token
+             WHERE Token = :to
+                ",
+            ['to' => $token]
+        );
+
+        if (!isset($candidTime[0]['EntryDate']) or !isset($candidTime[0]['CandidateID'])  ){
+            error_log("Error: No candidate found for token $token");
+            die();
+        }
+
+        $entryDate = $candidTime[0]['EntryDate'];
+        $candid = $candidTime[0]['CandidateID'];
+
+        //Checks if token more than a ~month old
+        if((time()-(60*60*24*30)) > strtotime($entryDate)){
+            error_log("The Given Token is expired: we are unable to connect this to a file");
+            die();
+
+        }
+
+
+        //TODO: REPLACE DIES WITH THROW ERROR
+
+        //TODO: Incude validation to make sure the consent object is complete (IE 9 rows), and that every row is complete!
+
+
+        //Attach to candidate --> start building proper object (generalized and to be tweaked on each loop)
+
+        $PSCID =  \Candidate::singleton($candid)->getPSCID();
+        //error_log($PSCID);
+
+        $ConsentParameters = array(
+        'ConsentStatus' => array (
+            'CandidateID'   => $candid,
+            'ConsentID'     => null,
+            'Status'        =>  null,
+            'DateGiven'     => null,
+            'DateWithdrawn' => null
+        ),
+
+        'ConsentHistory' => array (
+            'PSCID'         => $PSCID,
+            'ConsentName'   => null ,
+            'ConsentLabel'  => null,
+            'Status'        => null,
+            'DateGiven'     => null,
+            'DateWithdrawn' => null,
+            'EntryStaff'    => 'admin'
+        )
+    );
+
+
+
+
+
+
+      foreach ($ConsentList as $conName => $conInfo){
+            //error_log(print_r($conName, True));
+            //error_log(print_r($conInfo['Response'], True));
+
+          $consentIDLabel = $this->DB->pselect(
+              "SELECT ConsentID, Label
+                FROM consent
+             WHERE Name = :to
+                ",
+              ['to' => $conName]
+          );
+          //error_log(print_r($consentIDLabel, True));
+
+          $consentID = $consentIDLabel[0]['ConsentID'];
+          $consentLabel = $consentIDLabel[0]['Label'];
+
+          $ConsentParameters['ConsentHistory']['ConsentName'] = $conName;
+          $ConsentParameters['ConsentHistory']['ConsentLabel'] = $consentLabel;
+          $ConsentParameters['ConsentHistory']['Status'] = $conInfo['Response'];
+          $ConsentParameters['ConsentHistory']['DateGiven'] = $conInfo['Date'];
+
+
+          $ConsentParameters['ConsentStatus']['ConsentID'] = $consentID;
+          $ConsentParameters['ConsentStatus']['Status'] = $conInfo['Response'];
+          $ConsentParameters['ConsentStatus']['DateGiven'] = $conInfo['Date'];
+
+          //error_log(print_r($ConsentParameters, True));
+
+          \Candidate::singleton($candid)->editConsentStatusFields($ConsentParameters, $candid, $PSCID);
+
+
+
+        }
+
+
+
+        die();
+
+        /*TODO:Add Verification for TOKEN(?) and Consent List*/
+
+
+
+
+      // ADD date to token table!!! --> add checks in validation (is date recent, does token exist??) -->
+
+
+
+        /* Creation Code for token table
+         * CREATE TABLE `medhub_token` (
+    `CandidateID` int(6) NOT NULL,
+    `Token` varchar(255) NOT NULL,
+    `EntryDate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT `PK_medhub_token` PRIMARY KEY (`CandidateID`,`Token`),
+    CONSTRAINT `FK_medhub_token_CandidateID` FOREIGN KEY (`CandidateID`) REFERENCES `candidate` (`CandID`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+
+
+
+
+        INSERT INTO medhub_token (CandidateID, Token) VALUES ('908028', 'Token765Yup');
+
+        */
+
+
+
+
+        /*TODO: For Loop: for all consents, loop thru, and call the singleton update consent (need to match consent param object)*/
+
+
+        // create empty consent param array obj --> add candID, find consentID via name, answer = answer, date = date
+        //Is consent history necessary?? could that be why I had problems??
+
+
+
+
+
+
+
+    }
+
+
+    function calculateETag()
+    {
+
+        $ETagCriteria = $this->DB->pselectRow(
+            "SELECT MAX(TestDate) as Time,
+                    COUNT(DISTINCT CandID) as NumCandidates
+             FROM candidate WHERE Active='Y'",
+            array()
+        );
+        return md5(
+            'MedhubConsent:'
+            . $ETagCriteria['Time']
+            . ':' . $ETagCriteria['NumCandidates']
+        );
+    }
+
+
+}
+
+if (isset($_REQUEST['PrintCandidates'])) {
+    if ($_SERVER['REQUEST_METHOD'] === 'PUT') {
+        $fp   = fopen("php://input", "r");
+        $data = '';
+        while (!feof($fp)) {
+            $data .= fread($fp, 1024);
+        }
+        fclose($fp);
+
+        $obj = new MedhubConsent($_SERVER['REQUEST_METHOD'], json_decode($data, true));
+    } else {
+        $obj = new MedhubConsent($_SERVER['REQUEST_METHOD']);
+    }
+    print $obj->toJSONString();
+}
+
+
+
+
+
+
+
+
+
+
+
+

--- a/htdocs/api/v0.0.3-dev/MedhubConsent.php
+++ b/htdocs/api/v0.0.3-dev/MedhubConsent.php
@@ -61,7 +61,6 @@ class MedhubConsent extends APIBase {
         $consentList = $data['ConsentList'];
 
 
-
         //Check that every consent is represented AND all fields are set
         $consentNames = ['INF','HR', 'GEN', 'CL', 'CQ', 'CS', 'CR', 'ATPSY','ORPS'];
         foreach($consentNames as $conName){
@@ -95,24 +94,13 @@ class MedhubConsent extends APIBase {
             $this->safeExit(0);
         }
 
-        //Gets the mapping of consent IDs, Names, and Labels from the DB
-        $consentIDLabel = $this->DB->pselectWithIndexKey(
-            "SELECT ConsentID, Name, Label
-                FROM consent" ,
-            [], "Name"
-        );
 
         foreach ($consentList as $conName => $conInfo){
 
-            $consentID = $consentIDLabel[$conName]['ConsentID'];
-            $consentLabel = $consentIDLabel[$conName]['Label'];
-
             $consentArray = [];
             $consentArray['ConsentName'] = $conName;
-            $consentArray['ConsentLabel'] = $consentLabel;
             $consentArray['Status'] = $conInfo['Response'];
             $consentArray['DateGiven'] = $conInfo['Date'];
-            $consentArray['ConsentID'] = $consentID;
 
             try{
                 \Candidate::singleton($candid)->editConsentStatusFields($consentArray);

--- a/htdocs/api/v0.0.3-dev/MedhubConsent.php
+++ b/htdocs/api/v0.0.3-dev/MedhubConsent.php
@@ -81,12 +81,23 @@ class MedhubConsent extends APIBase {
             ['to' => $token]
         );
 
+
+        //Check that every consent is represented AND all fields are set
+        $consentNames = ['INF','HR', 'GEN', 'CL', 'CQ', 'CS', 'CR', 'ATPSY','ORPS'];
+        foreach($consentNames as $conName){
+            if (!isset($consentList[$conName]['Response'], $consentList[$conName]['Date'])){
+                error_log('Incomplete Consent Data');
+                $this->header("HTTP/1.1 400 Bad Request");
+                $this->safeExit(0);
+            }
+        }
+
+
         if (!isset($candidTimeUsed['EntryDate'],$candidTimeUsed['CandidateID'] )or isset($candidTimeUsed['AlreadyUsed'])){
-            error_log("Error: No candidate found for token $token");
+            error_log("Error: No candidate found for token $token or token already used");
             $this->header("HTTP/1.1 400 Bad Request");
             $this->safeExit(0);
         }
-
 
         $entryDate = $candidTimeUsed['EntryDate'];
         $candid = $candidTimeUsed['CandidateID'];
@@ -96,17 +107,12 @@ class MedhubConsent extends APIBase {
         $this->DB->update('medhub_token', $AlreadyUsed,['CandidateID' => $candid] );
 
 
-
-
-
         //Checks if token more than a ~month old
         if((time()-(60*60*24*30)) > strtotime($entryDate)){
             error_log("The Given Token is expired: we are unable to connect this to a file");
             $this->header("HTTP/1.1 400 Bad Request");
             $this->safeExit(0);
         }
-
-
 
         //TODO: Incude validation to make sure the consent object is complete (IE 9 rows), and that every row is complete!
 
@@ -136,45 +142,7 @@ class MedhubConsent extends APIBase {
 
 
         }
-
-
         $this->header("HTTP/1.1 201 Created");
-
-        /*TODO:Add Verification for TOKEN(?) and Consent List*/
-
-
-        /* Creation Code for token table
-         * CREATE TABLE `medhub_token` (
-    `CandidateID` int(6) NOT NULL,
-    `Token` varchar(255) NOT NULL,
-    'AlreadyUsed' varchar(255) NOT NULL,
-    `EntryDate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT `PK_medhub_token` PRIMARY KEY (`CandidateID`,`Token`),
-    CONSTRAINT `FK_medhub_token_CandidateID` FOREIGN KEY (`CandidateID`) REFERENCES `candidate` (`CandID`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-
-
-
-
-        INSERT INTO medhub_token (CandidateID, Token) VALUES ('908028', 'Token765Yup');
-
-        */
-
-
-
-
-        /*TODO: For Loop: for all consents, loop thru, and call the singleton update consent (need to match consent param object)*/
-
-
-        // create empty consent param array obj --> add candID, find consentID via name, answer = answer, date = date
-        //Is consent history necessary?? could that be why I had problems??
-
-
-
-
-
-
 
     }
 


### PR DESCRIPTION
## Brief summary of changes

2 things worth noting:
1). the editConsentStatus() function still makes 2 DB queries of essentially the same data, but indexes them differently
2). there are two places to comment/uncomment to change functionality : A: the delete lines in the cand class(currently uncommented) and B: the lines in medhubConsent which deactivate the token (currently commented)
#### Link(s) to related issue(s)

* Resolves #  (Reference the issue this fixes, if any.)
