### PR TITLE
[htdocs] Add French study title support for Biobank Open portal

### DIFF
--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -78,7 +78,14 @@ $baseURL = $settings->getBaseURL();
 $tpl_data['baseurl'] = $baseURL;
 
 // study title
-$tpl_data['study_title'] = $config->getSetting('title');
+$lang = strtoupper($_REQUEST['lang'] ?? 'EN');
+
+if ($lang === 'FR') {
+    $tpl_data['study_title']
+        = 'Portail de données de la Biobanque ouverte du Neuro (C-BIG)';
+} else {
+    $tpl_data['study_title'] = $config->getSetting('title');
+}
 
 if (!$anonymous) {
     tplFromRequest('candID');


### PR DESCRIPTION
**Related Issue**
*Addresses* aces/CBIGR#783

**Situation**

The CBIGR Open Biobank portal requires the study title to be displayed in French when the French language option is selected.

The current CBIGR Open instance uses:

- **CBIGR:** `aces/open`

- **LORIS:** `HenriRabalais/Biobank-open`

This branch is based on an older LORIS implementation and is expected to be replaced in the near future.

**Task**

Implement the French language requirement using a **minimal amount of changes**, avoiding a broader multilingual implementation.

**Action**

This PR introduces a minimal language-based title override in `htdocs/main.php`:

- Defaults to the existing English title

- Should now display the French title when `lang=FR`
